### PR TITLE
Reduce Sturdy Carapace blinking

### DIFF
--- a/src/main/java/paparatto/actions/PeelAction.java
+++ b/src/main/java/paparatto/actions/PeelAction.java
@@ -51,7 +51,7 @@ public class PeelAction extends AbstractGameAction {
 
                 if (AbstractDungeon.player.hasRelic("SturdyCarapace") && peelsThisTurn == 1) {
                     this.addToBot(new ApplyPowerAction(p,p, new MetallicizePower(p,2), 2));
-
+                    AbstractDungeon.player.getRelic("SturdyCarapace").stopPulse();
                 }
 
             }

--- a/src/main/java/paparatto/relics/SturdyCarapace.java
+++ b/src/main/java/paparatto/relics/SturdyCarapace.java
@@ -40,11 +40,13 @@ public class SturdyCarapace extends CustomRelic {
     }
 
     @Override
-    public void onPlayCard(AbstractCard c, AbstractMonster m) {
-        super.onPlayCard(c, m);
-        if (PeelAction.peelsThisTurn > 0 ) {
-            this.pulse = false;
-        }
+    public void onPlayerEndTurn() {
+        this.stopPulse();
+    }
+
+    @Override
+    public void onVictory() {
+        this.stopPulse();
     }
 
     @Override


### PR DESCRIPTION
Stop blinking on:

- Immediately on peel
- On rewards screen
- During enemy's turn

It seems we can't stop on loss, like Art of War, because there is no event for player death or game over.